### PR TITLE
add Ionide to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -397,3 +397,6 @@ paket-files/
 /Slides
 /*.pdf
 /slides
+
+# Ionide
+.ionide


### PR DESCRIPTION
I was in your workshop in Denver in Sept. 2019. The participants had to add to their .gitignore file. It would be better if the repo had it there for everyone.